### PR TITLE
Fix build for default CPUs different than -m68000

### DIFF
--- a/gcc/config/m68k/m68k.c
+++ b/gcc/config/m68k/m68k.c
@@ -628,7 +628,7 @@ m68k_option_override (void)
     {
       enum target_device dev;
       dev = all_microarchs[M68K_DEFAULT_TUNE].device;
-      m68k_tune_flags = all_devices[dev]->flags;
+      m68k_tune_flags = all_devices[dev].flags;
     }
 #endif
   else


### PR DESCRIPTION
I've realised I still manually apply this patch even when checking out from github. It has been fixed in later gcc versions.