### PR TITLE
Avoid conflicts with mintlib's ctype.h

### DIFF
--- a/include/safe-ctype.h
+++ b/include/safe-ctype.h
@@ -146,5 +146,18 @@ extern const unsigned char  _sch_tolower[256];
 #define toupper(c) do_not_use_toupper_with_safe_ctype
 #undef tolower
 #define tolower(c) do_not_use_tolower_with_safe_ctype
+#undef isblank
+#define isblank(c) do_not_use_isblank_with_safe_ctype
+
+#undef _CTc
+#undef _CTd
+#undef _CTu
+#undef _CTl
+#undef _CTs
+#undef _CTp
+#undef _CTx
+#undef _CTb
+#undef _CTg
+#undef _CTP
 
 #endif /* SAFE_CTYPE_H */

--- a/libstdc++-v3/include/c_global/cctype
+++ b/libstdc++-v3/include/c_global/cctype
@@ -58,6 +58,18 @@
 #undef isxdigit
 #undef tolower
 #undef toupper
+#undef isblank
+
+#undef _CTc
+#undef _CTd
+#undef _CTu
+#undef _CTl
+#undef _CTs
+#undef _CTp
+#undef _CTx
+#undef _CTb
+#undef _CTg
+#undef _CTP
 
 namespace std
 {


### PR DESCRIPTION
When compiling with `--enable-languages="c,c++"`, libstdc++ complains about conflicting types from mintlib:

```
libtool: compile:  /home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint-m68000-cross-final/./gcc/xgcc -shared-libgcc -B/home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint-m68000-cross-final/./gcc -nostdinc++ -L/home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint-m68000-cross-final/m68k-atari-mint/libstdc++-v3/src -L/home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint-m68000-cross-final/m68k-atari-mint/libstdc++-v3/src/.libs -L/home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint-m68000-cross-final/m68k-atari-mint/libstdc++-v3/libsupc++/.libs -B/home/mikro/gnu-tools/m68000/m68k-atari-mint/bin/ -B/home/mikro/gnu-tools/m68000/m68k-atari-mint/lib/ -isystem /home/mikro/gnu-tools/m68000/m68k-atari-mint/include -isystem /home/mikro/gnu-tools/m68000/m68k-atari-mint/sys-include -I/home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint/libstdc++-v3/../libgcc -I/home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint-m68000-cross-final/m68k-atari-mint/libstdc++-v3/include/m68k-atari-mint -I/home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint-m68000-cross-final/m68k-atari-mint/libstdc++-v3/include -I/home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint/libstdc++-v3/libsupc++ -std=gnu++98 -fno-implicit-templates -Wall -Wextra -Wwrite-strings -Wcast-qual -Wabi -fdiagnostics-show-location=once -D_GNU_SOURCE -frandom-seed=locale_init.lo -O2 -fomit-frame-pointer -std=gnu++11 -c ../../../../../m68k-atari-mint-gcc-gcc-7-mint/libstdc++-v3/src/c++98/locale_init.cc -o locale_init.o
In file included from /home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint-m68000-cross-final/m68k-atari-mint/libstdc++-v3/include/locale:38:0,
                 from ../../../../../m68k-atari-mint-gcc-gcc-7-mint/libstdc++-v3/src/c++98/locale_init.cc:29:
/home/mikro/atari/compilers/m68k-atari-mint-build/m68k-atari-mint-gcc-gcc-7-mint-m68000-cross-final/m68k-atari-mint/libstdc++-v3/include/bits/localefwd.h:113:34: error: macro "isblank" passed 2 arguments, but takes just 1
     isblank(_CharT, const locale&);
```
I'm not sure why this is happening, @th-otto mentions in the email introducing this patch:
> i replaced libstdc++-v3/config/os/mint/ctype_inline.h with a version that does not depend on mintlib, because the constants from ctype.h (_CTc etc) conflict with the c++ headers

I'd assume it was supposed to fix exactly this situation? (verified on the recent gcc-7-mint branch from the freemint repository).