### PR TITLE
Allow MAX_OFILE_ALIGNMENT, too

### DIFF
--- a/gcc/symtab.c
+++ b/gcc/symtab.c
@@ -2178,7 +2178,7 @@ increase_alignment_1 (symtab_node *n, void *v)
 void
 symtab_node::increase_alignment (unsigned int align)
 {
-  gcc_assert (can_increase_alignment_p () && align < MAX_OFILE_ALIGNMENT);
+  gcc_assert (can_increase_alignment_p () && align <= MAX_OFILE_ALIGNMENT);
   ultimate_alias_target()->call_for_symbol_and_aliases (increase_alignment_1,
 						        (void *)(size_t) align,
 						        true);


### PR DESCRIPTION
Accidentally found when compiling [antic.c](https://github.com/atari800/atari800/blob/master/src/antic.c):
```
m68k-atari-mint-gcc -c -o antic.o -DHAVE_CONFIG_H -I. -m68020-60 -O3 -fomit-frame-pointer -Wall  antic.c
antic.c: In function 'ANTIC_Initialise':
antic.c:946:5: internal compiler error: in increase_alignment, at symtab.c:2181
 int ANTIC_Initialise(int *argc, char *argv[])
     ^~~~~~~~~~~~~~~~
Please submit a full bug report,
with preprocessed source if appropriate.
See <https://gcc.gnu.org/bugs/> for instructions.
```
Unfortunately for us, it's a.out related and happens only with -O3 so it's a pretty good catch. Fixed thanks to @th-otto's suggestion:

> The function is called with align
> == 16. In a.out, MAX_OFILE_ALIGNMENT is configured to 16, while for elf it is
> much larger, that explains why it does not crash there.
> 
> The definition of MAX_OFILE_ALIGNMENT is inherited from BIGGEST_ALIGNMENT,
> which (for m68k) is defined as
> 
> #define BIGGEST_ALIGNMENT (TARGET_ALIGN_INT ? 32 : 16)
> 
> So my first try was to compile with -malign-int, but that only results on the
> function being called with align == 32, thus also crashing.
> 
> I think it is just the assertion that is wrong there (align <
> MAX_OFILE_ALIGNMENT), that should be <= i think.
> 
> In gcc 4.6.4, the only place i found that could correspond to this is in gcc/
> varasm.c:
> 
>   if (align > MAX_OFILE_ALIGNMENT)
>     {
>       warning (0, "alignment of %q+D is greater than maximum object "
>                "file alignment.  Using %d", decl,
>                MAX_OFILE_ALIGNMENT/BITS_PER_UNIT);
>       align = MAX_OFILE_ALIGNMENT;
>     }
> 
> so align == MAX_OFILE_ALIGNMENT is accepted there, and only generates a
> warning.