### PR TITLE
detect sha512 command

### DIFF
--- a/contrib/download_prerequisites
+++ b/contrib/download_prerequisites
@@ -46,14 +46,11 @@ verify=1
 force=0
 OS=$(uname)
 
-case $OS in
-  "Darwin")
-    chksum='shasum -a 512 --check'
-  ;;
-  *)
-    chksum='sha512sum --check'
-  ;;
-esac
+if type sha512sum > /dev/null ; then
+  chksum='sha512sum --check'
+else
+  chksum='shasum -a 512 --check'
+fi
 
 if type wget > /dev/null ; then
   fetch='wget'


### PR DESCRIPTION
So it works with sha512sum under linux, but also
with shasum -a 512 under macOS or FreeBSD.