### PR TITLE
New multilib: 68000, 68030, 68030/m68881, 68060, 5475

### DIFF
--- a/gcc/config/m68k/m68k.c
+++ b/gcc/config/m68k/m68k.c
@@ -358,10 +358,11 @@ struct gcc_target targetm = TARGET_INITIALIZER;
 #define FL_FOR_isa_10    (FL_FOR_isa_00 | FL_ISA_68010)
 /* FL_68881 controls the default setting of -m68881.  gcc has traditionally
    generated 68881 code for 68020 and 68030 targets unless explicitly told
-   not to.  */
-#define FL_FOR_isa_20    (FL_FOR_isa_10 | FL_ISA_68020 \
-			  | FL_BITFIELD | FL_68881 | FL_CAS)
-#define FL_FOR_isa_40    (FL_FOR_isa_20 | FL_ISA_68040)
+   not to.
+
+   Change this behaviour so it applies only to 68040 and 68060 targets.  */
+#define FL_FOR_isa_20    (FL_FOR_isa_10 | FL_ISA_68020 | FL_BITFIELD | FL_CAS)
+#define FL_FOR_isa_40    (FL_FOR_isa_20 | FL_68881 | FL_ISA_68040)
 #define FL_FOR_isa_cpu32 (FL_FOR_isa_10 | FL_ISA_68020)
 
 /* Base flags for ColdFire ISAs.  */

--- a/gcc/config/m68k/t-mint
+++ b/gcc/config/m68k/t-mint
@@ -1,5 +1,47 @@
-M68K_MLIB_CPU += && ((CPU ~ "^m68000") || (CPU ~ "^m68020") || (CPU ~ "^mcf5475"))
+M68K_MLIB_CPU += && ((CPU ~ "^m68000") || (CPU ~ "^m68020") || CPU ~ "^m68060" || (CPU ~ "^mcf5475"))
 
-M68K_MLIB_OPTIONS += mshort
+M68K_MLIB_OPTIONS += msoft-float/m68881 mshort
 
-M68K_MLIB_DIRNAMES += mshort
+M68K_MLIB_DIRNAMES += softfp m68881 mshort
+
+M68K_MLIB_MATCHES += \
+	m68881=mhard-float \
+	mcpu?68000=mc68000 \
+	mcpu?68000=mcpu?68010 \
+	mcpu?68020=mcpu?68030 \
+	mcpu?68020=mc68020 \
+	mcpu?68020=m68020-40 \
+	mcpu?68020=m68020-60 \
+	mcpu?68060=mcpu?68040 \
+	mcpu?5475=mcfv4e \
+	mcpu?5475=mcpu?5470 \
+	mcpu?5475=mcpu?5471 \
+	mcpu?5475=mcpu?5472 \
+	mcpu?5475=mcpu?5473 \
+	mcpu?5475=mcpu?5474 \
+	mcpu?5475=mcpu?547x \
+	mcpu?5475=mcpu?5480 \
+	mcpu?5475=mcpu?5481 \
+	mcpu?5475=mcpu?5482 \
+	mcpu?5475=mcpu?5483 \
+	mcpu?5475=mcpu?5484 \
+	mcpu?5475=mcpu?5485 \
+	mcpu?5475=mcpu?548x
+
+# "*" means other options (mshort in our case)
+M68K_MLIB_EXCEPTIONS += \
+	mcpu=68020/msoft-float* \
+	mcpu=68060/msoft-float* \
+	mcpu=5475/msoft-float* \
+	mcpu=68000/m68881* \
+	mcpu=68060/m68881* \
+	mcpu=5475/m68881*
+
+MULTILIB_REUSE += \
+	mcpu.68000=mcpu.68000/msoft-float \
+	mcpu.68000=mcpu.68000/m68881 \
+	mcpu.68000=mcpu.68060/msoft-float \
+	mcpu.68020=mcpu.68020/msoft-float \
+	mcpu.68060=mcpu.68060/m68881 \
+	mcpu.5475=mcpu.5475/msoft-float \
+	mcpu.5475=mcpu.5475/m68881

--- a/gcc/config/m68k/t-mlibs
+++ b/gcc/config/m68k/t-mlibs
@@ -45,10 +45,9 @@ ifeq ($(filter m$(M68K_MLIB_DEFAULT),$(M68K_MLIB_CPUS)),)
 $(error Error default cpu '$(target_cpu_default)' is not in multilib set '$(M68K_MLIB_CPUS)')
 endif
 
-MULTILIB_DIRNAMES := $(subst m68020,m68020-60,$(filter-out m$(M68K_MLIB_DEFAULT),$(M68K_MLIB_CPUS)))
+MULTILIB_DIRNAMES := $(filter-out m$(M68K_MLIB_DEFAULT),$(M68K_MLIB_CPUS))
 MULTILIB_OPTIONS := $(shell echo $(MULTILIB_DIRNAMES:m%=mcpu=%) \
-		      | sed -e 's| |/|g' \
-		      | sed -e 's|cpu=68020-60|68020-60|g' )
+		      | sed -e 's| |/|g' )
 
 # Add subtarget specific options & dirs.
 MULTILIB_DIRNAMES += $(M68K_MLIB_DIRNAMES)
@@ -59,44 +58,17 @@ MULTILIB_MATCHES :=
 ifneq ($(M68K_ARCH),cf)
 # Map -march=* options to the representative -mcpu=* option.
 MULTILIB_MATCHES += mcpu?68000=march?68000 \
+		    mcpu?68020=march?68020 \
+		    mcpu?68030=march?68030 \
+		    mcpu?68040=march?68040 \
+		    mcpu?68060=march?68060 \
 		    mcpu?cpu32=march?cpu32
-
-MULTILIB_MATCHES += m68020-60=m68881 \
-		    m68020-60=m68020 \
-		    m68020-60=m68020-40 \
-		    m68020-60=mc68020 \
-		    m68020-60=m68030 \
-		    m68020-60=m68040 \
-		    m68020-60=m68060 \
-		    m68020-60=mcpu?68020 \
-		    m68020-60=mcpu?68030 \
-		    m68020-60=mcpu?68040 \
-		    m68020-60=mcpu?68060 \
-		    m68020-60=march?68020 \
-		    m68020-60=march?68030 \
-		    m68020-60=march?68040 \
-		    m68020-60=march?68060
 endif
 
 ifneq ($(M68K_ARCH),m68k)
 # Map -march=* options to the representative -mcpu=* option.
 MULTILIB_MATCHES += mcpu?5206e=march?isaa mcpu?5208=march?isaaplus \
 		    mcpu?5407=march?isab
-
-MULTILIB_MATCHES += mcpu?5475=mcfv4e \
-		    mcpu?5475=mcpu?5470 \
-		    mcpu?5475=mcpu?5471 \
-		    mcpu?5475=mcpu?5472 \
-		    mcpu?5475=mcpu?5473 \
-		    mcpu?5475=mcpu?5474 \
-		    mcpu?5475=mcpu?547x \
-		    mcpu?5475=mcpu?5480 \
-		    mcpu?5475=mcpu?5481 \
-		    mcpu?5475=mcpu?5482 \
-		    mcpu?5475=mcpu?5483 \
-		    mcpu?5475=mcpu?5484 \
-		    mcpu?5475=mcpu?5485 \
-		    mcpu?5475=mcpu?548x
 endif
 
 # Match non-representative -mcpu options to their representative option.

--- a/gcc/config/m68k/t-mlibs
+++ b/gcc/config/m68k/t-mlibs
@@ -77,9 +77,12 @@ MULTILIB_MATCHES += \
 	 (CPU_NAME != MLIB) $(M68K_MLIB_CPU), \
 	 ("mcpu?"MLIB"=mcpu?"CPU_NAME))
 
+# Add subtarget specific matches.
+MULTILIB_MATCHES += $(M68K_MLIB_MATCHES)
+
 MULTILIB_EXCEPTIONS :=
 
-ifeq ($(firstword $(M68K_MLIB_OPTIONS)),msoft-float)
+ifeq ($(findstring msoft-float,$(subst /, ,$(M68K_MLIB_OPTIONS))),msoft-float)
 # Exclude soft-float multilibs for targets that default to soft-float anyway.
 MULTILIB_EXCEPTIONS += $(call M68K_AWK,\
 	(CPU_NAME == MLIB) $(M68K_MLIB_CPU) \
@@ -89,6 +92,15 @@ MULTILIB_EXCEPTIONS += $(call M68K_AWK,\
 	 "mcpu="MLIB"/msoft-float*")
 endif
 
+# Add subtarget specific exceptions.
+MULTILIB_EXCEPTIONS += $(M68K_MLIB_EXCEPTIONS)
+
 # Remove the default CPU from the explicit exceptions.
 MULTILIB_EXCEPTIONS := \
 	$(patsubst mcpu=$(M68K_MLIB_DEFAULT)/%,%,$(MULTILIB_EXCEPTIONS))
+
+# Remove the default CPU from the reused multilibs.
+MULTILIB_REUSE := \
+	$(patsubst mcpu.$(M68K_MLIB_DEFAULT)=%,,$(MULTILIB_REUSE))
+MULTILIB_REUSE := \
+	$(shell echo $(MULTILIB_REUSE) | sed -e "s|\(mcpu\..*=\)mcpu\.$(M68K_MLIB_DEFAULT)/\(.*\b\)|\1\2|g")


### PR DESCRIPTION
Making m68030 soft-float and m68060 hard-float by default required some creative thinking. This MR enables following multilib paths:

```
m68k-atari-mint-gcc -print-file-name=libgcc.a					libgcc.a

m68k-atari-mint-gcc -m68000 -print-file-name=libgcc.a				libgcc.a
m68k-atari-mint-gcc -m68000 -msoft-float -print-file-name=libgcc.a		libgcc.a
m68k-atari-mint-gcc -m68000 -mhard-float -print-file-name=libgcc.a		libgcc.a
m68k-atari-mint-gcc -m68000 -m68881 -print-file-name=libgcc.a			libgcc.a

m68k-atari-mint-gcc -m68030 -print-file-name=libgcc.a				m68020/libgcc.a
m68k-atari-mint-gcc -m68030 -msoft-float -print-file-name=libgcc.a		m68020/libgcc.a
m68k-atari-mint-gcc -m68030 -mhard-float -print-file-name=libgcc.a		m68020/m68881/libgcc.a
m68k-atari-mint-gcc -m68030 -m68881 -print-file-name=libgcc.a			m68020/m68881/libgcc.a

m68k-atari-mint-gcc -m68020-60 -print-file-name=libgcc.a			m68020/libgcc.a
m68k-atari-mint-gcc -m68020-60 -msoft-float -print-file-name=libgcc.a		m68020/libgcc.a
m68k-atari-mint-gcc -m68020-60 -mhard-float -print-file-name=libgcc.a		m68020/m68881/libgcc.a
m68k-atari-mint-gcc -m68020-60 -m68881 -print-file-name=libgcc.a		m68020/m68881/libgcc.a

m68k-atari-mint-gcc -m68040 -print-file-name=libgcc.a				m68060/libgcc.a
m68k-atari-mint-gcc -m68040 -msoft-float -print-file-name=libgcc.a		libgcc.a
m68k-atari-mint-gcc -m68040 -mhard-float -print-file-name=libgcc.a		m68060/libgcc.a
m68k-atari-mint-gcc -m68040 -m68881 -print-file-name=libgcc.a			m68060/libgcc.a

m68k-atari-mint-gcc -m68060 -print-file-name=libgcc.a				m68060/libgcc.a
m68k-atari-mint-gcc -m68060 -msoft-float -print-file-name=libgcc.a		libgcc.a
m68k-atari-mint-gcc -m68060 -mhard-float -print-file-name=libgcc.a		m68060/libgcc.a
m68k-atari-mint-gcc -m68060 -m68881 -print-file-name=libgcc.a			m68060/libgcc.a
```
(+ `mshort` variants)

`m68020` is used because that is what gcc uses by default also in other m68k targets and that `CPU ~ "^m68020"` check is based on ISA, not CPU name and I wanted to change as little as possible against upstream.

I have also added mapping `mcpu.5475=mcpu.5475/m68881` so `-mcpu=5475 -mhard-float` wont default into `/usr/lib/lib*.a`.

I'm not going to publish this anytime soon, I plan to backport also other m68k changes from gcc >= 8, too. Plus, if approved, we need to update mintlib & friends (see also freemint/fdlibm#4).

Fixes #1.