### PR TITLE
Port of Ada to FreeMiNT

### DIFF
--- a/gcc/ada/Makefile.rtl
+++ b/gcc/ada/Makefile.rtl
@@ -2370,6 +2370,33 @@ ifeq ($(strip $(filter-out m68k% linux%,$(target_cpu) $(target_os))),)
   LIBRARY_VERSION := $(LIB_VERSION)
 endif
 
+# M68K FreeMiNT
+ifeq ($(strip $(filter-out m68k% mint%,$(target_cpu) $(target_os))),)
+  LIBGNAT_TARGET_PAIRS = \
+  a-intnam.ads<libgnarl/a-intnam__mint.ads \
+  s-inmaop.adb<libgnarl/s-inmaop__posix.adb \
+  s-intman.adb<libgnarl/s-intman__posix.adb \
+  s-mint.ads<libgnarl/s-mint.ads \
+  s-osinte.adb<libgnarl/s-osinte__posix.adb \
+  s-osinte.ads<libgnarl/s-osinte__mint.ads \
+  s-osprim.adb<libgnat/s-osprim__posix.adb \
+  s-taprop.adb<libgnarl/s-taprop__linux.adb \
+  s-tasinf.ads<libgnarl/s-tasinf__linux.ads \
+  s-tasinf.adb<libgnarl/s-tasinf__linux.adb \
+  s-taspri.ads<libgnarl/s-taspri__posix.ads \
+  s-tpopsp.adb<libgnarl/s-tpopsp__posix-foreign.adb \
+  system.ads<libgnat/system-mint.ads
+
+  TOOLS_TARGET_PAIRS = indepsw.adb<indepsw-gnu.adb
+
+  EXTRA_GNATRTL_TASKING_OBJS=s-mint.o
+  EH_MECHANISM=-gcc
+  THREADSLIB =
+  GNATLIB_SHARED = gnatlib
+  GMEM_LIB = gmemlib
+  LIBRARY_VERSION := $(LIB_VERSION)
+endif
+
 # SH4 Linux
 ifeq ($(strip $(filter-out sh4% linux%,$(target_cpu) $(target_os))),)
   LIBGNAT_TARGET_PAIRS = \

--- a/gcc/ada/adaint.c
+++ b/gcc/ada/adaint.c
@@ -125,6 +125,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <time.h>
+#include <sys/time.h>
 
 #if defined (__vxworks) || defined (__ANDROID__)
 /* S_IREAD and S_IWRITE are not defined in VxWorks or Android */
@@ -3284,7 +3285,7 @@ __gnat_copy_attribs (char *from ATTRIBUTE_UNUSED, char *to ATTRIBUTE_UNUSED,
       return -1;
   }
 
-#elif _POSIX_C_SOURCE >= 200809L
+#elif _POSIX_C_SOURCE >= 200809L && defined(AT_FDCWD)
   struct timespec tbuf[2];
 
   if (mode != 2) {

--- a/gcc/ada/errno.c
+++ b/gcc/ada/errno.c
@@ -47,7 +47,7 @@ __get_errno(void)
   return errno;
 }
 
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(__set_errno)
 void
 __set_errno(int err)
 {

--- a/gcc/ada/exp_ch4.adb
+++ b/gcc/ada/exp_ch4.adb
@@ -4324,6 +4324,7 @@ package body Exp_Ch4 is
          --  too large, and which in the absence of a check results in
          --  undetected chaos ???
 
+         Len := 0;
          for J in 1 .. Number_Dimensions (E) loop
 
             if not Is_Modular_Integer_Type (Etype (Idx)) then

--- a/gcc/ada/gcc-interface/Make-lang.in
+++ b/gcc/ada/gcc-interface/Make-lang.in
@@ -936,7 +936,7 @@ gnat-install-tools:
 	    fi ; \
 	  done; \
 	  $(RM) $(DESTDIR)$(bindir)/gnatdll$(exeext); \
-	  $(INSTALL_PROGRAM) gnatdll$(exeext) $(DESTDIR)$(bindir)/gnatdll$(exeext); \
+	  test -f gnatdll$(exeext) && $(INSTALL_PROGRAM) gnatdll$(exeext) $(DESTDIR)$(bindir)/gnatdll$(exeext); \
 	fi
 
 #

--- a/gcc/ada/libgnarl/a-intnam__mint.ads
+++ b/gcc/ada/libgnarl/a-intnam__mint.ads
@@ -1,0 +1,154 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                 GNAT RUN-TIME LIBRARY (GNARL) COMPONENTS                 --
+--                                                                          --
+--                   A D A . I N T E R R U P T S . N A M E S                --
+--                                                                          --
+--                                  S p e c                                 --
+--                                                                          --
+--          Copyright (C) 1991-2020, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNARL is free software; you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNARL was developed by the GNARL team at Florida State University.       --
+-- Extensive contributions were provided by Ada Core Technologies, Inc.     --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This is a GNU/Linux version of this package
+
+--  The following signals are reserved by the run time:
+
+--  SIGFPE, SIGILL, SIGSEGV, SIGBUS, SIGTRAP, SIGABRT, SIGINT,
+--  SIGUSR1, SIGUSR2, SIGVTALRM, SIGUNUSED, SIGSTOP, SIGKILL
+
+--  The pragma Unreserve_All_Interrupts affects the following signal(s):
+
+--  SIGINT: made available for Ada handler
+
+--  This target-dependent package spec contains names of interrupts
+--  supported by the local system.
+
+with System.OS_Interface;
+
+package Ada.Interrupts.Names is
+
+   --  All identifiers in this unit are implementation defined
+
+   pragma Implementation_Defined;
+
+   --  Beware that the mapping of names to signals may be many-to-one. There
+   --  may be aliases. Also, for all signal names that are not supported on the
+   --  current system the value of the corresponding constant will be zero.
+
+   SIGHUP : constant Interrupt_ID :=
+     System.OS_Interface.SIGHUP;      --  hangup
+
+   SIGINT : constant Interrupt_ID :=
+     System.OS_Interface.SIGINT;      --  interrupt (rubout)
+
+   SIGQUIT : constant Interrupt_ID :=
+     System.OS_Interface.SIGQUIT;     --  quit (ASCD FS)
+
+   SIGILL : constant Interrupt_ID :=
+     System.OS_Interface.SIGILL;      --  illegal instruction (not reset)
+
+   SIGTRAP : constant Interrupt_ID :=
+     System.OS_Interface.SIGTRAP;     --  trace trap (not reset)
+
+   SIGIOT : constant Interrupt_ID :=
+     System.OS_Interface.SIGIOT;      --  IOT instruction
+
+   SIGABRT : constant Interrupt_ID := --  used by abort,
+     System.OS_Interface.SIGABRT;     --  replace SIGIOT in the  future
+
+   SIGFPE : constant Interrupt_ID :=
+     System.OS_Interface.SIGFPE;      --  floating point exception
+
+   SIGKILL : constant Interrupt_ID :=
+     System.OS_Interface.SIGKILL;     --  kill (cannot be caught or ignored)
+
+   SIGBUS : constant Interrupt_ID :=
+     System.OS_Interface.SIGBUS;      --  bus error
+
+   SIGSEGV : constant Interrupt_ID :=
+     System.OS_Interface.SIGSEGV;     --  segmentation violation
+
+   SIGPIPE : constant Interrupt_ID := --  write on a pipe with
+     System.OS_Interface.SIGPIPE;     --  no one to read it
+
+   SIGALRM : constant Interrupt_ID :=
+     System.OS_Interface.SIGALRM;     --  alarm clock
+
+   SIGTERM : constant Interrupt_ID :=
+     System.OS_Interface.SIGTERM;     --  software termination signal from kill
+
+   SIGUSR1 : constant Interrupt_ID :=
+     System.OS_Interface.SIGUSR1;     --  user defined signal 1
+
+   SIGUSR2 : constant Interrupt_ID :=
+     System.OS_Interface.SIGUSR2;     --  user defined signal 2
+
+   SIGCLD : constant Interrupt_ID :=
+     System.OS_Interface.SIGCLD;      --  child status change
+
+   SIGCHLD : constant Interrupt_ID :=
+     System.OS_Interface.SIGCHLD;     --  4.3BSD's/POSIX name for SIGCLD
+
+   SIGWINCH : constant Interrupt_ID :=
+     System.OS_Interface.SIGWINCH;    --  window size change
+
+   SIGURG : constant Interrupt_ID :=
+     System.OS_Interface.SIGURG;      --  urgent condition on IO channel
+
+   SIGIO : constant Interrupt_ID :=   --  input/output possible,
+     System.OS_Interface.SIGIO;       --  SIGPOLL alias (Solaris)
+
+   SIGSTOP : constant Interrupt_ID :=
+     System.OS_Interface.SIGSTOP;     --  stop (cannot be caught or ignored)
+
+   SIGTSTP : constant Interrupt_ID :=
+     System.OS_Interface.SIGTSTP;     --  user stop requested from tty
+
+   SIGCONT : constant Interrupt_ID :=
+     System.OS_Interface.SIGCONT;     --  stopped process has been continued
+
+   SIGTTIN : constant Interrupt_ID :=
+     System.OS_Interface.SIGTTIN;     --  background tty read attempted
+
+   SIGTTOU : constant Interrupt_ID :=
+     System.OS_Interface.SIGTTOU;     --  background tty write attempted
+
+   SIGVTALRM : constant Interrupt_ID :=
+     System.OS_Interface.SIGVTALRM;   --  virtual timer expired
+
+   SIGPROF : constant Interrupt_ID :=
+     System.OS_Interface.SIGPROF;     --  profiling timer expired
+
+   SIGXCPU : constant Interrupt_ID :=
+     System.OS_Interface.SIGXCPU;     --  CPU time limit exceeded
+
+   SIGXFSZ : constant Interrupt_ID :=
+     System.OS_Interface.SIGXFSZ;     --  filesize limit exceeded
+
+   SIGPWR : constant Interrupt_ID :=
+     System.OS_Interface.SIGPWR;        --  Power failure
+
+   SIGSYS : constant Interrupt_ID :=
+     System.OS_Interface.SIGSYS;       --  bad system call
+
+end Ada.Interrupts.Names;

--- a/gcc/ada/libgnarl/s-mint.ads
+++ b/gcc/ada/libgnarl/s-mint.ads
@@ -1,0 +1,118 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                GNU ADA RUN-TIME LIBRARY (GNARL) COMPONENTS               --
+--                                                                          --
+--                          S Y S T E M .  M I N T                          --
+--                                                                          --
+--                                  S p e c                                 --
+--                                                                          --
+--          Copyright (C) 2008-2020, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNARL is free software; you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This is the default version of this package
+
+--  This package encapsulates cpu specific differences between implementations
+--  of GNU/Linux, in order to share s-osinte-linux.ads.
+
+--  PLEASE DO NOT add any with-clauses to this package or remove the pragma
+--  Preelaborate. This package is designed to be a bottom-level (leaf) package
+
+with Interfaces.C;
+
+package System.Mint is
+   pragma Preelaborate;
+
+   ----------
+   -- Time --
+   ----------
+
+   subtype long        is Interfaces.C.long;
+   subtype suseconds_t is Interfaces.C.long;
+   subtype time_t      is Interfaces.C.long;
+   subtype clockid_t   is Interfaces.C.int;
+
+   type timespec is record
+      tv_sec  : time_t;
+      tv_nsec : long;
+   end record;
+   pragma Convention (C, timespec);
+
+   type timeval is record
+      tv_sec  : time_t;
+      tv_usec : suseconds_t;
+   end record;
+   pragma Convention (C, timeval);
+
+   -----------
+   -- Errno --
+   -----------
+
+   EAGAIN    : constant := 236;
+   EINTR     : constant := 128;
+   EINVAL    : constant := 25;
+   ENOMEM    : constant := 39;
+   EPERM     : constant := 38;
+   ETIMEDOUT : constant := 320;
+
+   -------------
+   -- Signals --
+   -------------
+
+   SIGHUP     : constant := 1; --  hangup
+   SIGINT     : constant := 2; --  interrupt (rubout)
+   SIGQUIT    : constant := 3; --  quit (ASCD FS)
+   SIGILL     : constant := 4; --  illegal instruction (not reset)
+   SIGTRAP    : constant := 5; --  trace trap (not reset)
+   SIGIOT     : constant := 6; --  IOT instruction
+   SIGABRT    : constant := 6; --  used by abort, replace SIGIOT in the future
+   SIGPRIV    : constant := 7; --  privilege violation
+   SIGFPE     : constant := 8; --  floating point exception
+   SIGKILL    : constant := 9; --  kill (cannot be caught or ignored)
+   SIGBUS     : constant := 10; --  bus error
+   SIGSEGV    : constant := 11; --  segmentation violation
+   SIGSYS     : constant := 12; --  bad system call
+   SIGPIPE    : constant := 13; --  write on a pipe with no one to read it
+   SIGALRM    : constant := 14; --  alarm clock
+   SIGTERM    : constant := 15; --  software termination signal from kill
+   SIGURG     : constant := 16; --  urgent condition on IO channel
+   SIGSTOP    : constant := 17; --  stop (cannot be caught or ignored)
+   SIGTSTP    : constant := 18; --  user stop requested from tty
+   SIGCONT    : constant := 19; --  stopped process has been continued
+   SIGCLD     : constant := 20; --  alias for SIGCHLD
+   SIGCHLD    : constant := 20; --  child status change
+   SIGTTIN    : constant := 21; --  background tty read attempted
+   SIGTTOU    : constant := 22; --  background tty write attempted
+   SIGIO      : constant := 23; --  I/O now possible (4.2 BSD)
+   SIGXCPU    : constant := 24; --  CPU time limit exceeded
+   SIGXFSZ    : constant := 25; --  filesize limit exceeded
+   SIGVTALRM  : constant := 26; --  virtual timer expired
+   SIGPROF    : constant := 27; --  profiling timer expired
+   SIGWINCH   : constant := 28; --  window size change
+   SIGUSR1    : constant := 29; --  user defined signal 1
+   SIGUSR2    : constant := 30; --  user defined signal 2
+   SIGPWR     : constant := 31; --  power-fail restart
+
+   --  struct_sigaction
+
+   SA_SIGINFO  : constant := 16#04#;
+   SA_ONSTACK  : constant := 16#08000000#;
+
+end System.Mint;

--- a/gcc/ada/libgnarl/s-osinte__mint.ads
+++ b/gcc/ada/libgnarl/s-osinte__mint.ads
@@ -1,0 +1,642 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                 GNAT RUN-TIME LIBRARY (GNARL) COMPONENTS                 --
+--                                                                          --
+--                   S Y S T E M . O S _ I N T E R F A C E                  --
+--                                                                          --
+--                                  S p e c                                 --
+--                                                                          --
+--             Copyright (C) 1991-2017, Florida State University            --
+--          Copyright (C) 1995-2020, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNARL was developed by the GNARL team at Florida State University.       --
+-- Extensive contributions were provided by Ada Core Technologies, Inc.     --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This is a FreeMiNT version of this package
+
+--  This package encapsulates all direct interfaces to OS services
+--  that are needed by the tasking run-time (libgnarl).
+
+--  PLEASE DO NOT add any with-clauses to this package or remove the pragma
+--  Preelaborate. This package is designed to be a bottom-level (leaf) package.
+
+with Ada.Unchecked_Conversion;
+with Interfaces.C;
+with System.Mint;
+with System.OS_Constants;
+
+package System.OS_Interface is
+   pragma Preelaborate;
+
+   subtype int            is Interfaces.C.int;
+   subtype char           is Interfaces.C.char;
+   subtype short          is Interfaces.C.short;
+   subtype long           is Interfaces.C.long;
+   subtype unsigned       is Interfaces.C.unsigned;
+   subtype unsigned_short is Interfaces.C.unsigned_short;
+   subtype unsigned_long  is Interfaces.C.unsigned_long;
+   subtype unsigned_char  is Interfaces.C.unsigned_char;
+   subtype plain_char     is Interfaces.C.plain_char;
+   subtype size_t         is Interfaces.C.size_t;
+
+   -----------
+   -- Errno --
+   -----------
+
+   EAGAIN    : constant := System.Mint.EAGAIN;
+   EINTR     : constant := System.Mint.EINTR;
+   EINVAL    : constant := System.Mint.EINVAL;
+   ENOMEM    : constant := System.Mint.ENOMEM;
+   EPERM     : constant := System.Mint.EPERM;
+   ETIMEDOUT : constant := System.Mint.ETIMEDOUT;
+
+   -------------
+   -- Signals --
+   -------------
+
+   Max_Interrupt : constant := 31;
+   type Signal is new int range 0 .. Max_Interrupt;
+   for Signal'Size use int'Size;
+
+   SIGNULL    : constant := 0;
+   SIGHUP     : constant := System.Mint.SIGHUP;
+   SIGINT     : constant := System.Mint.SIGINT;
+   SIGQUIT    : constant := System.Mint.SIGQUIT;
+   SIGILL     : constant := System.Mint.SIGILL;
+   SIGTRAP    : constant := System.Mint.SIGTRAP;
+   SIGIOT     : constant := System.Mint.SIGIOT;
+   SIGABRT    : constant := System.Mint.SIGABRT;
+   SIGPRIV    : constant := System.Mint.SIGPRIV;
+   SIGFPE     : constant := System.Mint.SIGFPE;
+   SIGKILL    : constant := System.Mint.SIGKILL;
+   SIGBUS     : constant := System.Mint.SIGBUS;
+   SIGSEGV    : constant := System.Mint.SIGSEGV;
+   SIGSYS     : constant := System.Mint.SIGSYS;
+   SIGPIPE    : constant := System.Mint.SIGPIPE;
+   SIGALRM    : constant := System.Mint.SIGALRM;
+   SIGTERM    : constant := System.Mint.SIGTERM;
+   SIGURG     : constant := System.Mint.SIGURG;
+   SIGSTOP    : constant := System.Mint.SIGSTOP;
+   SIGTSTP    : constant := System.Mint.SIGTSTP;
+   SIGCONT    : constant := System.Mint.SIGCONT;
+   SIGCLD     : constant := System.Mint.SIGCLD;
+   SIGCHLD    : constant := System.Mint.SIGCHLD;
+   SIGTTIN    : constant := System.Mint.SIGTTIN;
+   SIGTTOU    : constant := System.Mint.SIGTTOU;
+   SIGIO      : constant := System.Mint.SIGIO;
+   SIGXCPU    : constant := System.Mint.SIGXCPU;
+   SIGXFSZ    : constant := System.Mint.SIGXFSZ;
+   SIGVTALRM  : constant := System.Mint.SIGVTALRM;
+   SIGPROF    : constant := System.Mint.SIGPROF;
+   SIGWINCH   : constant := System.Mint.SIGWINCH;
+   SIGUSR1    : constant := System.Mint.SIGUSR1;
+   SIGUSR2    : constant := System.Mint.SIGUSR2;
+   SIGPWR     : constant := System.Mint.SIGPWR;
+
+   SIGADAABORT : constant := SIGABRT;
+   --  Change this to use another signal for task abort. SIGTERM might be a
+   --  good one.
+
+   type Signal_Set is array (Natural range <>) of Signal;
+
+   Unmasked : constant Signal_Set := (
+      SIGTRAP,
+      --  To enable debugging on multithreaded applications, mark SIGTRAP to
+      --  be kept unmasked.
+
+      SIGBUS,
+
+      SIGTTIN, SIGTTOU, SIGTSTP,
+      --  Keep these three signals unmasked so that background processes and IO
+      --  behaves as normal "C" applications
+
+      SIGPROF,
+      --  To avoid confusing the profiler
+
+      SIGKILL, SIGSTOP
+      --  These two signals actually can't be masked (POSIX won't allow it)
+      );
+
+   Reserved : constant Signal_Set := (SIGNULL, SIGNULL);
+
+   type sigset_t is private;
+
+   function sigaddset (set : access sigset_t; sig : Signal) return int;
+   pragma Import (C, sigaddset, "sigaddset");
+
+   function sigdelset (set : access sigset_t; sig : Signal) return int;
+   pragma Import (C, sigdelset, "sigdelset");
+
+   function sigfillset (set : access sigset_t) return int;
+   pragma Import (C, sigfillset, "sigfillset");
+
+   function sigismember (set : access sigset_t; sig : Signal) return int;
+   pragma Import (C, sigismember, "sigismember");
+
+   function sigemptyset (set : access sigset_t) return int;
+   pragma Import (C, sigemptyset, "sigemptyset");
+
+   type union_type_3 is new String (1 .. 116);
+   type siginfo_t is record
+      si_signo : int;
+      si_code  : int;
+      si_errno : int;
+      X_data   : union_type_3;
+   end record;
+   pragma Convention (C, siginfo_t);
+
+   type struct_sigaction is record
+      sa_handler  : System.Address;
+      sa_mask     : sigset_t;
+      sa_flags    : int;
+      sa_restorer : System.Address;
+   end record;
+   pragma Convention (C, struct_sigaction);
+
+   type struct_sigaction_ptr is access all struct_sigaction;
+
+   SA_SIGINFO : constant := System.Mint.SA_SIGINFO;
+   SA_ONSTACK : constant := System.Mint.SA_ONSTACK;
+
+   SIG_BLOCK   : constant := 0;
+   SIG_UNBLOCK : constant := 1;
+   SIG_SETMASK : constant := 2;
+
+   SIG_DFL : constant := 0;
+   SIG_IGN : constant := 1;
+
+   function sigaction
+     (sig  : Signal;
+      act  : struct_sigaction_ptr;
+      oact : struct_sigaction_ptr) return int;
+   pragma Import (C, sigaction, "sigaction");
+
+   ----------
+   -- Time --
+   ----------
+
+   subtype time_t    is System.Mint.time_t;
+   subtype timespec  is System.Mint.timespec;
+   subtype timeval   is System.Mint.timeval;
+   subtype clockid_t is System.Mint.clockid_t;
+
+   function clock_gettime
+     (clock_id : clockid_t; tp : access timespec) return int;
+   pragma Import (C, clock_gettime, "clock_gettime");
+
+   function clock_getres
+     (clock_id : clockid_t;
+      res      : access timespec) return int;
+   pragma Import (C, clock_getres, "clock_getres");
+
+   function To_Duration (TS : timespec) return Duration;
+   pragma Inline (To_Duration);
+
+   function To_Timespec (D : Duration) return timespec;
+   pragma Inline (To_Timespec);
+
+   function sysconf (name : int) return long;
+   pragma Import (C, sysconf);
+
+   SC_CLK_TCK          : constant := 5;
+   SC_NPROCESSORS_ONLN : constant := 3015;
+
+   -------------------------
+   -- Priority Scheduling --
+   -------------------------
+
+   SCHED_OTHER : constant := 0;
+   SCHED_FIFO  : constant := 1;
+   SCHED_RR    : constant := 2;
+
+   function To_Target_Priority
+     (Prio : System.Any_Priority) return Interfaces.C.int;
+   --  Maps System.Any_Priority to a POSIX priority
+
+   -------------
+   -- Process --
+   -------------
+
+   type pid_t is private;
+
+   function kill (pid : pid_t; sig : Signal) return int;
+   pragma Import (C, kill, "kill");
+
+   function getpid return pid_t;
+   pragma Import (C, getpid, "getpid");
+
+   PR_SET_NAME : constant := 15;
+   PR_GET_NAME : constant := 16;
+
+   function prctl
+     (option : int;
+      arg    : unsigned_long) return int;
+   pragma Import (C_Variadic_1, prctl, "prctl");
+
+   -------------
+   -- Threads --
+   -------------
+
+   type Thread_Body is access
+     function (arg : System.Address) return System.Address;
+   pragma Convention (C, Thread_Body);
+
+   function Thread_Body_Access is new
+     Ada.Unchecked_Conversion (System.Address, Thread_Body);
+
+   type pthread_t is new unsigned_long;
+   subtype Thread_Id is pthread_t;
+
+   function To_pthread_t is
+     new Ada.Unchecked_Conversion (unsigned_long, pthread_t);
+
+   type pthread_mutex_t      is limited private;
+   type pthread_rwlock_t     is limited private;
+   type pthread_cond_t       is limited private;
+   type pthread_attr_t       is limited private;
+   type pthread_mutexattr_t  is limited private;
+   type pthread_rwlockattr_t is limited private;
+   type pthread_condattr_t   is limited private;
+   type pthread_key_t        is private;
+
+   PTHREAD_CREATE_DETACHED : constant := 1;
+
+   -----------
+   -- Stack --
+   -----------
+
+   subtype char_array is Interfaces.C.char_array;
+
+   type stack_t is record
+      ss_sp    : System.Address;
+      ss_flags : int;
+      ss_size  : size_t;
+   end record;
+   pragma Convention (C, stack_t);
+
+   function sigaltstack
+     (ss  : not null access stack_t;
+      oss : access stack_t) return int;
+   pragma Import (C, sigaltstack, "sigaltstack");
+
+   Alternate_Stack_Size : constant := 32 * 1024;
+   --  This must be in keeping with init.c:__gnat_alternate_stack
+
+   Alternate_Stack : aliased char_array (1 .. Alternate_Stack_Size);
+   pragma Import (C, Alternate_Stack, "__gnat_alternate_stack");
+   --  The alternate signal stack for stack overflows
+
+   function Get_Stack_Base (thread : pthread_t) return Address;
+   pragma Inline (Get_Stack_Base);
+   --  This is a dummy procedure to share some GNULLI files
+
+   ---------------------------------------
+   -- Nonstandard Thread Initialization --
+   ---------------------------------------
+
+   procedure pthread_init;
+   pragma Inline (pthread_init);
+   --  This is a dummy procedure to share some GNULLI files
+
+   -------------------------
+   -- POSIX.1c  Section 3 --
+   -------------------------
+
+   function sigwait (set : access sigset_t; sig : access Signal) return int;
+   pragma Import (C, sigwait, "sigwait");
+
+   function pthread_kill (thread : pthread_t; sig : Signal) return int;
+   pragma Import (C, pthread_kill, "pthread_kill");
+
+   function pthread_sigmask
+     (how  : int;
+      set  : access sigset_t;
+      oset : access sigset_t) return int;
+   pragma Import (C, pthread_sigmask, "pthread_sigmask");
+
+   --------------------------
+   -- POSIX.1c  Section 11 --
+   --------------------------
+
+   function pthread_mutexattr_init
+     (attr : access pthread_mutexattr_t) return int;
+   pragma Import (C, pthread_mutexattr_init, "pthread_mutexattr_init");
+
+   function pthread_mutexattr_destroy
+     (attr : access pthread_mutexattr_t) return int;
+   pragma Import (C, pthread_mutexattr_destroy, "pthread_mutexattr_destroy");
+
+   function pthread_mutex_init
+     (mutex : access pthread_mutex_t;
+      attr  : access pthread_mutexattr_t) return int;
+   pragma Import (C, pthread_mutex_init, "pthread_mutex_init");
+
+   function pthread_mutex_destroy (mutex : access pthread_mutex_t) return int;
+   pragma Import (C, pthread_mutex_destroy, "pthread_mutex_destroy");
+
+   function pthread_mutex_lock (mutex : access pthread_mutex_t) return int;
+   pragma Import (C, pthread_mutex_lock, "pthread_mutex_lock");
+
+   function pthread_mutex_unlock (mutex : access pthread_mutex_t) return int;
+   pragma Import (C, pthread_mutex_unlock, "pthread_mutex_unlock");
+
+   function pthread_rwlockattr_init
+     (attr : access pthread_rwlockattr_t) return int;
+   pragma Import (C, pthread_rwlockattr_init, "pthread_rwlockattr_init");
+
+   function pthread_rwlockattr_destroy
+     (attr : access pthread_rwlockattr_t) return int;
+   pragma Import (C, pthread_rwlockattr_destroy, "pthread_rwlockattr_destroy");
+
+   PTHREAD_RWLOCK_PREFER_READER_NP              : constant := 0;
+   PTHREAD_RWLOCK_PREFER_WRITER_NP              : constant := 1;
+   PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP : constant := 2;
+
+   function pthread_rwlockattr_setkind_np
+     (attr : access pthread_rwlockattr_t;
+      pref : int) return int;
+   pragma Import
+     (C, pthread_rwlockattr_setkind_np, "pthread_rwlockattr_setkind_np");
+
+   function pthread_rwlock_init
+     (mutex : access pthread_rwlock_t;
+      attr  : access pthread_rwlockattr_t) return int;
+   pragma Import (C, pthread_rwlock_init, "pthread_rwlock_init");
+
+   function pthread_rwlock_destroy
+     (mutex : access pthread_rwlock_t) return int;
+   pragma Import (C, pthread_rwlock_destroy, "pthread_rwlock_destroy");
+
+   function pthread_rwlock_rdlock (mutex : access pthread_rwlock_t) return int;
+   pragma Import (C, pthread_rwlock_rdlock, "pthread_rwlock_rdlock");
+
+   function pthread_rwlock_wrlock (mutex : access pthread_rwlock_t) return int;
+   pragma Import (C, pthread_rwlock_wrlock, "pthread_rwlock_wrlock");
+
+   function pthread_rwlock_unlock (mutex : access pthread_rwlock_t) return int;
+   pragma Import (C, pthread_rwlock_unlock, "pthread_rwlock_unlock");
+
+   function pthread_condattr_init
+     (attr : access pthread_condattr_t) return int;
+   pragma Import (C, pthread_condattr_init, "pthread_condattr_init");
+
+   function pthread_condattr_destroy
+     (attr : access pthread_condattr_t) return int;
+   pragma Import (C, pthread_condattr_destroy, "pthread_condattr_destroy");
+
+   function pthread_cond_init
+     (cond : access pthread_cond_t;
+      attr : access pthread_condattr_t) return int;
+   pragma Import (C, pthread_cond_init, "pthread_cond_init");
+
+   function pthread_cond_destroy (cond : access pthread_cond_t) return int;
+   pragma Import (C, pthread_cond_destroy, "pthread_cond_destroy");
+
+   function pthread_cond_signal (cond : access pthread_cond_t) return int;
+   pragma Import (C, pthread_cond_signal, "pthread_cond_signal");
+
+   function pthread_cond_wait
+     (cond  : access pthread_cond_t;
+      mutex : access pthread_mutex_t) return int;
+   pragma Import (C, pthread_cond_wait, "pthread_cond_wait");
+
+   function pthread_cond_timedwait
+     (cond    : access pthread_cond_t;
+      mutex   : access pthread_mutex_t;
+      abstime : access timespec) return int;
+   pragma Import (C, pthread_cond_timedwait, "pthread_cond_timedwait");
+
+   --------------------------
+   -- POSIX.1c  Section 13 --
+   --------------------------
+
+   PTHREAD_PRIO_NONE    : constant := 0;
+   PTHREAD_PRIO_INHERIT : constant := 1;
+   PTHREAD_PRIO_PROTECT : constant := 2;
+
+   function pthread_mutexattr_setprotocol
+     (attr     : access pthread_mutexattr_t;
+      protocol : int) return int;
+   pragma Import (C, pthread_mutexattr_setprotocol);
+
+   function pthread_mutexattr_setprioceiling
+     (attr        : access pthread_mutexattr_t;
+      prioceiling : int) return int;
+   pragma Import (C, pthread_mutexattr_setprioceiling);
+
+   type struct_sched_param is record
+      sched_priority : int;  --  scheduling priority
+   end record;
+   pragma Convention (C, struct_sched_param);
+
+   function pthread_setschedparam
+     (thread : pthread_t;
+      policy : int;
+      param  : access struct_sched_param) return int;
+   pragma Import (C, pthread_setschedparam, "pthread_setschedparam");
+
+   function pthread_attr_setschedpolicy
+     (attr   : access pthread_attr_t;
+      policy : int) return int;
+   pragma Import
+     (C, pthread_attr_setschedpolicy, "pthread_attr_setschedpolicy");
+
+   function sched_yield return int;
+   pragma Import (C, sched_yield, "sched_yield");
+
+   ---------------------------
+   -- P1003.1c - Section 16 --
+   ---------------------------
+
+   function pthread_attr_init
+     (attributes : access pthread_attr_t) return int;
+   pragma Import (C, pthread_attr_init, "pthread_attr_init");
+
+   function pthread_attr_destroy
+     (attributes : access pthread_attr_t) return int;
+   pragma Import (C, pthread_attr_destroy, "pthread_attr_destroy");
+
+   function pthread_attr_setdetachstate
+     (attr        : access pthread_attr_t;
+      detachstate : int) return int;
+   pragma Import
+     (C, pthread_attr_setdetachstate, "pthread_attr_setdetachstate");
+
+   function pthread_attr_setstacksize
+     (attr      : access pthread_attr_t;
+      stacksize : size_t) return int;
+   pragma Import (C, pthread_attr_setstacksize, "pthread_attr_setstacksize");
+
+   function pthread_create
+     (thread        : access pthread_t;
+      attributes    : access pthread_attr_t;
+      start_routine : Thread_Body;
+      arg           : System.Address) return int;
+   pragma Import (C, pthread_create, "pthread_create");
+
+   procedure pthread_exit (status : System.Address);
+   pragma Import (C, pthread_exit, "pthread_exit");
+
+   function pthread_self return pthread_t;
+   pragma Import (C, pthread_self, "pthread_self");
+
+   function lwp_self return System.Address;
+   pragma Import (C, lwp_self, "__gnat_lwp_self");
+
+   --------------------------
+   -- POSIX.1c  Section 17 --
+   --------------------------
+
+   function pthread_setspecific
+     (key   : pthread_key_t;
+      value : System.Address) return int;
+   pragma Import (C, pthread_setspecific, "pthread_setspecific");
+
+   function pthread_getspecific (key : pthread_key_t) return System.Address;
+   pragma Import (C, pthread_getspecific, "pthread_getspecific");
+
+   type destructor_pointer is access procedure (arg : System.Address);
+   pragma Convention (C, destructor_pointer);
+
+   function pthread_key_create
+     (key        : access pthread_key_t;
+      destructor : destructor_pointer) return int;
+   pragma Import (C, pthread_key_create, "pthread_key_create");
+
+   ----------------
+   -- Extensions --
+   ----------------
+
+   CPU_SETSIZE : constant := 1_024;
+   --  Size of the cpu_set_t mask on most linux systems (SUSE 11 uses 4_096).
+   --  This is kept for backward compatibility (System.Task_Info uses it), but
+   --  the run-time library does no longer rely on static masks, using
+   --  dynamically allocated masks instead.
+
+   type bit_field is array (1 .. CPU_SETSIZE) of Boolean;
+   for bit_field'Size use CPU_SETSIZE;
+   pragma Pack (bit_field);
+   pragma Convention (C, bit_field);
+
+   type cpu_set_t is record
+      bits : bit_field;
+   end record;
+   pragma Convention (C, cpu_set_t);
+
+   type cpu_set_t_ptr is access all cpu_set_t;
+   --  In the run-time library we use this pointer because the size of type
+   --  cpu_set_t varies depending on the glibc version. Hence, objects of type
+   --  cpu_set_t are allocated dynamically using the number of processors
+   --  available in the target machine (value obtained at execution time).
+
+   function CPU_ALLOC (count : size_t) return cpu_set_t_ptr;
+   pragma Import (C, CPU_ALLOC, "__gnat_cpu_alloc");
+   --  Wrapper around the CPU_ALLOC C macro
+
+   function CPU_ALLOC_SIZE (count : size_t) return size_t;
+   pragma Import (C, CPU_ALLOC_SIZE, "__gnat_cpu_alloc_size");
+   --  Wrapper around the CPU_ALLOC_SIZE C macro
+
+   procedure CPU_FREE (cpuset : cpu_set_t_ptr);
+   pragma Import (C, CPU_FREE, "__gnat_cpu_free");
+   --  Wrapper around the CPU_FREE C macro
+
+   procedure CPU_ZERO (count : size_t; cpuset : cpu_set_t_ptr);
+   pragma Import (C, CPU_ZERO, "__gnat_cpu_zero");
+   --  Wrapper around the CPU_ZERO_S C macro
+
+   procedure CPU_SET (cpu : int; count : size_t; cpuset : cpu_set_t_ptr);
+   pragma Import (C, CPU_SET, "__gnat_cpu_set");
+   --  Wrapper around the CPU_SET_S C macro
+
+   function pthread_setaffinity_np
+     (thread     : pthread_t;
+      cpusetsize : size_t;
+      cpuset     : cpu_set_t_ptr) return int;
+   pragma Import (C, pthread_setaffinity_np, "pthread_setaffinity_np");
+   pragma Weak_External (pthread_setaffinity_np);
+   --  Use a weak symbol because this function may be available or not,
+   --  depending on the version of the system.
+
+   function pthread_attr_setaffinity_np
+     (attr       : access pthread_attr_t;
+      cpusetsize : size_t;
+      cpuset     : cpu_set_t_ptr) return int;
+   pragma Import (C, pthread_attr_setaffinity_np,
+                    "pthread_attr_setaffinity_np");
+   pragma Weak_External (pthread_attr_setaffinity_np);
+   --  Use a weak symbol because this function may be available or not,
+   --  depending on the version of the system.
+
+private
+
+   type sigset_t is
+     array (0 .. OS_Constants.SIZEOF_sigset - 1) of unsigned_char;
+   pragma Convention (C, sigset_t);
+   for sigset_t'Alignment use Interfaces.C.unsigned_long'Alignment;
+
+   type pid_t is new int;
+
+   type pthread_attr_t is record
+      Data : char_array (1 .. OS_Constants.PTHREAD_ATTR_SIZE);
+   end record;
+   pragma Convention (C, pthread_attr_t);
+   for pthread_attr_t'Alignment use Interfaces.C.unsigned_long'Alignment;
+
+   type pthread_condattr_t is record
+      Data : char_array (1 .. OS_Constants.PTHREAD_CONDATTR_SIZE);
+   end record;
+   pragma Convention (C, pthread_condattr_t);
+   for pthread_condattr_t'Alignment use Interfaces.C.int'Alignment;
+
+   type pthread_mutexattr_t is record
+      Data : char_array (1 .. OS_Constants.PTHREAD_MUTEXATTR_SIZE);
+   end  record;
+   pragma Convention (C, pthread_mutexattr_t);
+   for pthread_mutexattr_t'Alignment use Interfaces.C.int'Alignment;
+
+   type pthread_mutex_t is record
+      Data : char_array (1 .. OS_Constants.PTHREAD_MUTEX_SIZE);
+   end record;
+   pragma Convention (C, pthread_mutex_t);
+   for pthread_mutex_t'Alignment use Interfaces.C.unsigned_long'Alignment;
+
+   type pthread_rwlockattr_t is record
+      Data : char_array (1 .. OS_Constants.PTHREAD_RWLOCKATTR_SIZE);
+   end record;
+   pragma Convention (C, pthread_rwlockattr_t);
+   for pthread_rwlockattr_t'Alignment use Interfaces.C.unsigned_long'Alignment;
+
+   type pthread_rwlock_t is record
+      Data : char_array (1 .. OS_Constants.PTHREAD_RWLOCK_SIZE);
+   end record;
+   pragma Convention (C, pthread_rwlock_t);
+   for pthread_rwlock_t'Alignment use Interfaces.C.unsigned_long'Alignment;
+
+   type pthread_cond_t is record
+      Data : char_array (1 .. OS_Constants.PTHREAD_COND_SIZE);
+   end record;
+   pragma Convention (C, pthread_cond_t);
+   for pthread_cond_t'Alignment use Interfaces.Unsigned_64'Alignment;
+
+   type pthread_key_t is new unsigned;
+
+end System.OS_Interface;

--- a/gcc/ada/libgnat/g-sechas.ads
+++ b/gcc/ada/libgnat/g-sechas.ads
@@ -45,7 +45,7 @@ with System;
 package GNAT.Secure_Hashes is
 
    type Buffer_Type is new Stream_Element_Array;
-   for Buffer_Type'Alignment use 8;
+   --  for Buffer_Type'Alignment use 8;
    --  Secure hash functions use a string buffer that is also accessed as an
    --  array of words, which may require up to 64 bit alignment.
 

--- a/gcc/ada/libgnat/g-sothco.ads
+++ b/gcc/ada/libgnat/g-sothco.ads
@@ -211,7 +211,7 @@ package GNAT.Sockets.Thin_Common is
 
    type Hostent is new
      System.Storage_Elements.Storage_Array (1 .. SOSC.SIZEOF_struct_hostent);
-   for Hostent'Alignment use 8;
+   --  for Hostent'Alignment use 8;
    --  Host entry. This is an opaque type used only via the following
    --  accessor functions, because 'struct hostent' has different layouts on
    --  different platforms.
@@ -241,7 +241,7 @@ package GNAT.Sockets.Thin_Common is
 
    type Servent is new
      System.Storage_Elements.Storage_Array (1 .. SOSC.SIZEOF_struct_servent);
-   for Servent'Alignment use 8;
+   --  for Servent'Alignment use 8;
    --  Service entry. This is an opaque type used only via the following
    --  accessor functions, because 'struct servent' has different layouts on
    --  different platforms.

--- a/gcc/ada/libgnat/i-cexten.ads
+++ b/gcc/ada/libgnat/i-cexten.ads
@@ -70,7 +70,7 @@ package Interfaces.C.Extensions is
       low, high : unsigned_long_long;
    end record;
    pragma Convention (C_Pass_By_Copy, Signed_128);
-   for Signed_128'Alignment use unsigned_long_long'Alignment * 2;
+   --  for Signed_128'Alignment use unsigned_long_long'Alignment * 2;
 
    --  128-bit floating-point type available on x86:
    --  typedef float float_128 __attribute__ ((mode (TF)));
@@ -79,7 +79,7 @@ package Interfaces.C.Extensions is
       low, high : unsigned_long_long;
    end record;
    pragma Convention (C_Pass_By_Copy, Float_128);
-   for Float_128'Alignment use unsigned_long_long'Alignment * 2;
+   --  for Float_128'Alignment use unsigned_long_long'Alignment * 2;
 
    --  128-bit complex floating-point type available on x86:
    --  typedef _Complex float cfloat_128 __attribute__ ((mode (TC)));

--- a/gcc/ada/libgnat/s-bitfie.ads
+++ b/gcc/ada/libgnat/s-bitfie.ads
@@ -43,9 +43,9 @@ package System.Bitfields is
    Val_Bits  : constant := Long_Long_Integer'Size / 2;
    Val_Bytes : constant := Val_Bits / System.Storage_Unit;
 
-   type Val_2 is mod 2**(Val_Bits * 2) with Alignment => Val_Bytes;
+   type Val_2 is mod 2**(Val_Bits * 2) with Alignment => 2;
    pragma Provide_Shift_Operators (Val_2);
-   type Val is mod 2**Val_Bits with Alignment => Val_Bytes;
+   type Val is mod 2**Val_Bits with Alignment => 2;
 
    --  Enabling checks on the instantiation of System.Bitfield_Utils.G makes a
    --  latent visibility bug appear on strict alignment platforms related to

--- a/gcc/ada/libgnat/s-bituti.ads
+++ b/gcc/ada/libgnat/s-bituti.ads
@@ -85,7 +85,7 @@ package System.Bitfield_Utils is
       --  Assert that both are aligned the same, to the size in bytes of Val
       --  (not Val_2).
 
-      pragma Assert (Val'Alignment = Val'Size / Storage_Unit);
+      pragma Assert (Val'Alignment = 2);
       pragma Assert (Val_2'Alignment = Val'Alignment);
 
       type Val_Array is array (Positive range <>) of Val;

--- a/gcc/ada/libgnat/s-secsta.ads
+++ b/gcc/ada/libgnat/s-secsta.ads
@@ -262,7 +262,7 @@ private
    --  Index into the memory storage of a single chunk
 
    type Chunk_Memory is array (Memory_Size range <>) of SSE.Storage_Element;
-   for Chunk_Memory'Alignment use Standard'Maximum_Alignment;
+   --  for Chunk_Memory'Alignment use Standard'Maximum_Alignment;
    --  The memory storage of a single chunk
 
    --------------

--- a/gcc/ada/libgnat/system-mint.ads
+++ b/gcc/ada/libgnat/system-mint.ads
@@ -1,0 +1,145 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                        GNAT RUN-TIME COMPONENTS                          --
+--                                                                          --
+--                               S Y S T E M                                --
+--                                                                          --
+--                                 S p e c                                  --
+--                         (freemint/m68k Version)                          --
+--                                                                          --
+--          Copyright (C) 2014-2020, Free Software Foundation, Inc.         --
+--                                                                          --
+-- This specification is derived from the Ada Reference Manual for use with --
+-- GNAT. The copyright notice above, and the license provisions that follow --
+-- apply solely to the  contents of the part following the private keyword. --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package System is
+   pragma Pure;
+   --  Note that we take advantage of the implementation permission to make
+   --  this unit Pure instead of Preelaborable; see RM 13.7.1(15). In Ada
+   --  2005, this is Pure in any case (AI-362).
+
+   pragma No_Elaboration_Code_All;
+   --  Allow the use of that restriction in units that WITH this unit
+
+   type Name is (SYSTEM_NAME_GNAT);
+   System_Name : constant Name := SYSTEM_NAME_GNAT;
+
+   --  System-Dependent Named Numbers
+
+   Min_Int             : constant := -2 ** (Standard'Max_Integer_Size - 1);
+   Max_Int             : constant :=  2 ** (Standard'Max_Integer_Size - 1) - 1;
+
+   Max_Binary_Modulus    : constant := 2 ** Standard'Max_Integer_Size;
+   Max_Nonbinary_Modulus : constant := 2 ** Integer'Size - 1;
+
+   Max_Base_Digits       : constant := Long_Long_Float'Digits;
+   Max_Digits            : constant := Long_Long_Float'Digits;
+
+   Max_Mantissa          : constant := Standard'Max_Integer_Size - 1;
+   Fine_Delta            : constant := 2.0 ** (-Max_Mantissa);
+
+   Tick                  : constant := 0.05;
+
+   --  Storage-related Declarations
+
+   type Address is private;
+   pragma Preelaborable_Initialization (Address);
+   Null_Address : constant Address;
+
+   Storage_Unit : constant := 8;
+   Word_Size    : constant := 32;
+   Memory_Size  : constant := 2 ** 32;
+
+   --  Address comparison
+
+   function "<"  (Left, Right : Address) return Boolean;
+   function "<=" (Left, Right : Address) return Boolean;
+   function ">"  (Left, Right : Address) return Boolean;
+   function ">=" (Left, Right : Address) return Boolean;
+   function "="  (Left, Right : Address) return Boolean;
+
+   pragma Import (Intrinsic, "<");
+   pragma Import (Intrinsic, "<=");
+   pragma Import (Intrinsic, ">");
+   pragma Import (Intrinsic, ">=");
+   pragma Import (Intrinsic, "=");
+
+   --  Other System-Dependent Declarations
+
+   type Bit_Order is (High_Order_First, Low_Order_First);
+   Default_Bit_Order : constant Bit_Order := High_Order_First;
+   pragma Warnings (Off, Default_Bit_Order); -- kill constant condition warning
+
+   --  Priority-related Declarations (RM D.1)
+
+   Max_Priority           : constant Positive := 30;
+   Max_Interrupt_Priority : constant Positive := 31;
+
+   subtype Any_Priority       is Integer      range  0 .. 31;
+   subtype Priority           is Any_Priority range  0 .. 30;
+   subtype Interrupt_Priority is Any_Priority range 31 .. 31;
+
+   Default_Priority : constant Priority := 15;
+
+private
+
+   type Address is mod Memory_Size;
+   Null_Address : constant Address := 0;
+
+   --------------------------------------
+   -- System Implementation Parameters --
+   --------------------------------------
+
+   --  These parameters provide information about the target that is used
+   --  by the compiler. They are in the private part of System, where they
+   --  can be accessed using the special circuitry in the Targparm unit
+   --  whose source should be consulted for more detailed descriptions
+   --  of the individual switch values.
+
+   Backend_Divide_Checks     : constant Boolean := False;
+   Backend_Overflow_Checks   : constant Boolean := True;
+   Command_Line_Args         : constant Boolean := True;
+   Configurable_Run_Time     : constant Boolean := False;
+   Denorm                    : constant Boolean := True;
+   Duration_32_Bits          : constant Boolean := False;
+   Exit_Status_Supported     : constant Boolean := True;
+   Machine_Overflows         : constant Boolean := False;
+   Machine_Rounds            : constant Boolean := True;
+   Preallocated_Stacks       : constant Boolean := False;
+   Signed_Zeros              : constant Boolean := True;
+   Stack_Check_Default       : constant Boolean := False;
+   Stack_Check_Probes        : constant Boolean := False;
+   Stack_Check_Limits        : constant Boolean := False;
+   Support_Aggregates        : constant Boolean := True;
+   Support_Atomic_Primitives : constant Boolean := True;
+   Support_Composite_Assign  : constant Boolean := True;
+   Support_Composite_Compare : constant Boolean := True;
+   Support_Long_Shifts       : constant Boolean := True;
+   Always_Compatible_Rep     : constant Boolean := False;
+   Suppress_Standard_Library : constant Boolean := False;
+   Use_Ada_Main_Program_Name : constant Boolean := False;
+   ZCX_By_Default            : constant Boolean := True;
+
+end System;

--- a/gcc/ada/s-oscons-tmplt.c
+++ b/gcc/ada/s-oscons-tmplt.c
@@ -86,7 +86,7 @@ pragma Style_Checks ("M32766");
  ** a number of non-POSIX but useful/required features.
  **/
 
-#if defined (__linux__) || defined (__ANDROID__)
+#if defined (__linux__) || defined (__ANDROID__) || defined(__MINT__)
 
 /* Define _XOPEN_SOURCE to get IOV_MAX */
 # if !defined (_XOPEN_SOURCE)
@@ -160,7 +160,7 @@ pragma Style_Checks ("M32766");
 #endif
 
 #if defined (__linux__) || defined (__ANDROID__) || defined (__QNX__) \
-  || defined (__rtems__)
+  || defined (__rtems__) || defined(__MINT__)
 # include <pthread.h>
 # include <signal.h>
 #endif
@@ -1210,12 +1210,12 @@ CND(NI_NUMERICSERV, "Numeric form of the service")
 CND(NI_NUMERICHOST, "Numeric form of the hostname")
 
 #ifndef NI_MAXHOST
-# define NI_MAXHOST -1
+# define NI_MAXHOST 1025
 #endif
 CND(NI_MAXHOST, "Maximum size of hostname")
 
 #ifndef NI_MAXSERV
-# define NI_MAXSERV -1
+# define NI_MAXSERV 32
 #endif
 CND(NI_MAXSERV, "Maximum size of service name")
 
@@ -1796,7 +1796,7 @@ CND(SIZEOF_struct_hostent, "struct hostent")
 #define SIZEOF_struct_servent (sizeof (struct servent))
 CND(SIZEOF_struct_servent, "struct servent")
 
-#if defined (__linux__) || defined (__ANDROID__) || defined (__QNX__)
+#if defined (__linux__) || defined (__ANDROID__) || defined (__QNX__) || defined(__MINT__)
 #define SIZEOF_sigset (sizeof (sigset_t))
 CND(SIZEOF_sigset, "sigset")
 #endif
@@ -1992,7 +1992,7 @@ CNS(CLOCK_RT_Ada, "")
 #endif
 
 #if defined (__APPLE__) || defined (__linux__) || defined (__ANDROID__) \
-  || defined (__QNX__) || defined (__rtems__) || defined (DUMMY)
+  || defined (__QNX__) || defined (__rtems__) || defined (DUMMY) || defined(__MINT__)
 /*
 
    --  Sizes of pthread data types

--- a/gcc/ada/terminals.c
+++ b/gcc/ada/terminals.c
@@ -34,7 +34,7 @@
 /* First all usupported platforms. Add stubs for exported routines. */
 
 #if defined (VMS) || defined (__vxworks) || defined (__Lynx__) \
-  || defined (__ANDROID__) || defined (__PikeOS__) || defined(__DJGPP__)
+  || defined (__ANDROID__) || defined (__PikeOS__) || defined(__DJGPP__) || defined(__MINT__)
 
 void *
 __gnat_new_tty (void)


### PR DESCRIPTION
These are changes (courtesy of † Thorsten Otto) to allow building m68k gnat (the GNU Ada compiler) cherry-picked from Thorsten's github.
A merge into FreeMinT's gcc repository serves these purposes:

- ensure the work doesn't get lost
- as Thorsten's sysroot changes are not merged, it allows to install the compiler to its standard location (`/usr/bin` or `/usr/local/bin`) just as before

Originally marked as experimental, I see no reason why this shouldn*t get included as it works flawlessly for me with the following limitations:

- Ada's tasking (aka multi-threading) environment is not functional (will stay this way until we have a proper libpthread implementation)
- m68k-atari-mintelf linker's inability to properly garbage-collect unused sections results in huge binaries (same as with c++)

There are no other changes to the compiler (building without Ada should result in the exact same binaries as before)
Building requires a native gnat installation with the same version (i.e. gnat-13). Build with
```
GNATBIND=gnatbind-13 CC=gcc-13 CXX=g++-13 ../configure --target=m68k-atari-mintelf --prefix=/usr --enabl
e-languages=ada,c,c++ --disable-nls --disable-libstdcxx-pch --disable-libcc1 --disable-sjlj-exceptions -
-disable-fixincludes CFLAGS_FOR_TARGET="-O2 -fomit-frame-pointer -ffunction-sections -fdata-sections" CX
XFLAGS_FOR_TARGET="-O2 -fomit-frame-pointer" LDFLAGS_FOR_TARGET="-Wl,--gc-sections" ADA_FOR_TARGET="-O2 
-fomit-frame-pointer -ffunction-sections -fdata-sections"
```
There are a few Ada example programs (including incomplete GEM bindings) in my github repository.
